### PR TITLE
Removed oldest-supported-numpy-version because it's creating a dependency loop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=59.0",
     "Cython<3.0",
-    "oldest-supported-numpy; python_version<'3.12'",
+    "python_version<'3.12'",
     "numpy>=1.26.0b1; python_version>='3.12'"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=59.0",
     "Cython<3.0",
-    "python_version<'3.12'",
+    "numpy; python_version<'3.12'",
     "numpy>=1.26.0b1; python_version>='3.12'"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "embreex"
-version = "2.17.7.post3"
+version = "2.17.7.post4"
 dependencies = [
     "numpy; python_version<'3.12'",
     "numpy>=1.26.0b1; python_version>='3.12'"


### PR DESCRIPTION
The version of numpy required by the build system is different than the oldest supported version, which means that pip gets confused about what version of numpy must be installed on the system.