### PR TITLE
Use tomli to parse pyproject.toml on Python 3.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=59.0",
+    "tomli>=0.10; python_version<'3.7'",
     "Cython<3.0",
     "numpy; python_version<'3.12'",
     "numpy>=1.26.0b1; python_version>='3.12'"

--- a/setup.py
+++ b/setup.py
@@ -56,22 +56,16 @@ def load_pyproject() -> dict:
     if sys.version_info >= (3, 7):
         return {}
 
-    # store loaded values from the toml
-    values = {}
-    import json
+    import tomli
 
-    # load the toml data with naive string wangling
     with open(os.path.join(_cwd, 'pyproject.toml'), 'r') as f:
-        for line in f:
-            if '=' not in line:
-                continue
-            split = [i.strip() for i in line.strip().split('=')]
-            if split[0] in ('name', 'version'):
-                values[split[0]] = json.loads(split[1])
-    # hardcode numpy dependency on python 3.6
-    values['install_requires'] = ["numpy"]
+        pyproject = tomli.load(f)
 
-    return values
+    return {
+        "name": pyproject["project"]["name"],
+        "version": pyproject["project"]["version"],
+        "install_requires": pyproject["project"]["dependencies"],
+    }
 
 
 try:


### PR DESCRIPTION
Instead of custom parsing