### PR TITLE
Release: Embree 4

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: '3.14'
     - name: Install cibuildwheel
       run: |
-        python -m pip install cibuildwheel==3.4.0
+        python -m pip install cibuildwheel==3.4.1
     - name: Build wheel
       run: |
         python -m cibuildwheel --output-dir dist

--- a/embreex/__init__.py
+++ b/embreex/__init__.py
@@ -1,3 +1,3 @@
 from importlib.metadata import version as _get_version
 
-__version__ = version("embreex")
+__version__ = _get_version("embreex")

--- a/embreex/__init__.py
+++ b/embreex/__init__.py
@@ -1,1 +1,3 @@
-__version__ = "0.1.6"
+from importlib.metadata import version as _get_version
+
+__version__ = version("embreex")

--- a/package/fetch-embree.py
+++ b/package/fetch-embree.py
@@ -212,14 +212,14 @@ def is_current_platform(platform: str, architecture: Optional[str]) -> bool:
 
     if architecture is not None:
         # Check for cibuildwheel target architecture first
-        target_arch = os.environ.get('ARCHFLAGS', '')
-        if 'arm64' in target_arch:
-            machine = 'arm64'
-        elif 'x86_64' in target_arch:
-            machine = 'x86_64'
+        target_arch = os.environ.get("ARCHFLAGS", "")
+        if "arm64" in target_arch:
+            machine = "arm64"
+        elif "x86_64" in target_arch:
+            machine = "x86_64"
         else:
             machine = uname().machine.lower()
-        
+
         if architecture.lower() not in machine.lower():
             return False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "embreex"
 requires-python = ">=3.8"
-version = "4.4.0rc1"
+version = "4.4.0"
 
 dependencies = ["numpy"]
 description = "Python binding for Intel's Embree ray engine"

--- a/setup.py
+++ b/setup.py
@@ -15,19 +15,23 @@ def ext_modules():
     """Generate a list of extension modules for embreex."""
     if os.name == "nt":
         # embree search locations on windows
-        includes = [get_include(),
-                    'c:/Program Files/Intel/Embree4/include',
-                    os.path.join(_cwd, 'embree4', 'include')]
+        includes = [
+            get_include(),
+            "c:/Program Files/Intel/Embree4/include",
+            os.path.join(_cwd, "embree4", "include"),
+        ]
         libraries = [
-            'c:/Program Files/Intel/Embree4/lib',
-            os.path.join(_cwd, 'embree4', 'lib')]
+            "c:/Program Files/Intel/Embree4/lib",
+            os.path.join(_cwd, "embree4", "lib"),
+        ]
     else:
         # embree search locations on posix
-        includes = [get_include(),
-                    '/opt/local/include',
-                    os.path.join(_cwd, 'embree4', 'include')]
-        libraries = ['/opt/local/lib',
-                     os.path.join(_cwd, 'embree4', 'lib')]
+        includes = [
+            get_include(),
+            "/opt/local/include",
+            os.path.join(_cwd, "embree4", "include"),
+        ]
+        libraries = ["/opt/local/lib", os.path.join(_cwd, "embree4", "lib")]
 
     ext_modules = cythonize("embreex/*.pyx", include_path=includes, language_level=3)
     for ext in ext_modules:
@@ -39,7 +43,7 @@ def ext_modules():
             # Add rpath to find libembree4 during build and set loader_path for runtime
             ext.extra_link_args = [
                 "-Wl,-rpath,@loader_path",
-                "-Wl,-rpath," + os.path.join(_cwd, 'embree4', 'lib')
+                "-Wl,-rpath," + os.path.join(_cwd, "embree4", "lib"),
             ]
         else:
             ext.libraries = ["embree4"]


### PR DESCRIPTION
The first non-candidate release for `embreex` that moves from embree 2.X which we've been stuck on for many years to embree 4.X. Thanks to everyone who followed and poked #1!

- Hopefully lets us track [embree releases](https://github.com/RenderKit/embree/releases) more closely in the future. 
- This PR was largely finished by Claude and tested by hand.
- switches to `robust` mode by default which fixes a lot of "why are these ray queries wrong" that surfaced in trimesh.
- removes unused values in the `pxd`
- fixes `embreex.__version__`, which has apparently been hardcoded to a completely incorrect value for many forks and years.
- releases Python's GIL during ray queries, which also has the happy behavior of failing to compile if any "reference Python value in a hot loop" happens rather than the previous behavior where `.run(... output=True)` had one of these and a silent 10x slowdown. The `output` is the plane-location calculation and this should let trimesh use embree's hit location rather than recalculating it in Python land. 